### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/henrique-pettenuci/prober/security/code-scanning/1](https://github.com/henrique-pettenuci/prober/security/code-scanning/1)

To address this issue, we need to explicitly add a `permissions` key to restrict the GITHUB_TOKEN's access for this workflow (or job) to the least privilege required. In this case, since the job only needs to checkout code and run tests (not create releases, modify code, or write to PRs), setting `contents: read` is minimally sufficient. This can be specified at either the workflow root or directly under the job. Given only one job exists, adding it at either level is fine, but per the CodeQL suggestion, placing it at the job level ("test") is very clear and precise.

**Region to change:**  
In file `.github/workflows/pr-tests.yml`, insert a permissions block with `contents: read` under the "test" job (after line 8, before "runs-on").

**What is needed:**  
- Insert the following below line 8:
  ```yaml
    permissions:
      contents: read
  ```

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
